### PR TITLE
FIX - Faster loading symbols for Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@modelcontextprotocol/sdk": "^1.17.4",
         "fast-glob": "^3.3.3",
         "glob": "^11.0.3",
-        "stream-json": "^1.9.1"
+        "stream-json": "^1.9.1",
+        "yauzl": "^3.2.0"
       },
       "bin": {
         "al-mcp-server": "dist/cli/install.js"
@@ -20,6 +21,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^24.3.0",
+        "@types/yauzl": "^2.10.3",
         "jest": "^30.1.1",
         "ts-jest": "^29.4.1",
         "ts-node": "^10.9.2",
@@ -1460,6 +1462,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -2063,6 +2075,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -4758,6 +4779,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6128,6 +6155,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -52,11 +52,13 @@
     "@modelcontextprotocol/sdk": "^1.17.4",
     "fast-glob": "^3.3.3",
     "glob": "^11.0.3",
-    "stream-json": "^1.9.1"
+    "stream-json": "^1.9.1",
+    "yauzl": "^3.2.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^24.3.0",
+    "@types/yauzl": "^2.10.3",
     "jest": "^30.1.1",
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
@StefanMaron 

I've changed the way of loading symbols on Windows. I used yauzl package, it's unzip library build in Node. 

Loading symbols from alpackages took forever and after my changes it took only 3 seconds. 

Please, consider merging those changes so we could enjoy your mcp server still on windows as well. 

