### PR TITLE
feat: add support for extension object types (TableExtension, PageExt…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ logs/
 *.app
 rad.json
 !tests/fixtures/*.json
+tests/fixtures/compiled/
+tests/fixtures/*/rad.json

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  globalSetup: './tests/fixtures/compile-fixtures.ts',
   roots: ['<rootDir>/src', '<rootDir>/tests'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
   transform: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1434,6 +1435,7 @@
       "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -2041,6 +2043,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -2761,6 +2764,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3466,6 +3470,7 @@
       "integrity": "sha512-yC3JvpP/ZcAZX5rYCtXO/g9k6VTCQz0VFE2v1FpxytWzUqfDtu0XL/pwnNvptzYItvGwomh1ehomRNMOyhCJKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.1.1",
         "@jest/types": "30.0.5",
@@ -5679,6 +5684,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5768,6 +5774,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6198,6 +6205,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/core/symbol-database.ts
+++ b/src/core/symbol-database.ts
@@ -181,8 +181,8 @@ export class OptimizedSymbolDatabase implements ALSymbolDatabase {
     
     for (const obj of this.allObjects) {
       if (obj.Name === objectName) {
-        if (obj.Type === 'Report' && (obj as any).DataItems) {
-          results.push(...((obj as any).DataItems));
+        if (obj.Type === 'Report' && (obj as any).Dataset) {
+          results.push(...((obj as any).Dataset));
         } else if (obj.Type === 'Query' && (obj as any).DataItems) {
           results.push(...((obj as any).DataItems));
         } else if (obj.Type === 'XmlPort' && (obj as any).Schema) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export class ALMCPServer {
                 objectType: {
                   type: 'string',
                   description: 'Filter by type',
-                  enum: ['Table', 'Page', 'Codeunit', 'Report', 'Enum', 'Interface', 'PermissionSet', 'XmlPort', 'Query'],
+                  enum: ['Table', 'TableExtension', 'Page', 'PageExtension', 'Codeunit', 'Report', 'ReportExtension', 'Enum', 'EnumExtensionType', 'Interface', 'PermissionSet', 'PermissionSetExtension', 'XmlPort', 'Query'],
                 },
                 packageName: {
                   type: 'string',
@@ -123,7 +123,7 @@ export class ALMCPServer {
                 objectType: {
                   type: 'string',
                   description: 'Object type',
-                  enum: ['Table', 'Page', 'Codeunit', 'Report', 'Enum', 'Interface', 'PermissionSet', 'XmlPort', 'Query'],
+                  enum: ['Table', 'TableExtension', 'Page', 'PageExtension', 'Codeunit', 'Report', 'ReportExtension', 'Enum', 'EnumExtensionType', 'Interface', 'PermissionSet', 'PermissionSetExtension', 'XmlPort', 'Query'],
                 },
                 packageName: {
                   type: 'string',
@@ -177,7 +177,7 @@ export class ALMCPServer {
                 sourceType: {
                   type: 'string',
                   description: 'Source object type filter',
-                  enum: ['Table', 'Page', 'Codeunit', 'Report', 'Query', 'XmlPort', 'Enum', 'Interface'],
+                  enum: ['Table', 'TableExtension', 'Page', 'PageExtension', 'Codeunit', 'Report', 'ReportExtension', 'Enum', 'EnumExtensionType', 'Interface', 'PermissionSet', 'PermissionSetExtension', 'XmlPort', 'Query'],
                 },
                 includeContext: {
                   type: 'boolean',
@@ -201,7 +201,7 @@ export class ALMCPServer {
                 objectType: {
                   type: 'string',
                   description: 'Object type (optional)',
-                  enum: ['Table', 'Page', 'Codeunit', 'Report', 'Query', 'XmlPort'],
+                  enum: ['Table', 'TableExtension', 'Page', 'PageExtension', 'Codeunit', 'Report', 'ReportExtension', 'Query', 'XmlPort'],
                 },
                 memberType: {
                   type: 'string',
@@ -244,7 +244,7 @@ export class ALMCPServer {
                 objectType: {
                   type: 'string',
                   description: 'Object type (optional)',
-                  enum: ['Table', 'Page', 'Codeunit', 'Report', 'Enum', 'Interface', 'PermissionSet', 'XmlPort', 'Query'],
+                  enum: ['Table', 'TableExtension', 'Page', 'PageExtension', 'Codeunit', 'Report', 'ReportExtension', 'Enum', 'EnumExtensionType', 'Interface', 'PermissionSet', 'PermissionSetExtension', 'XmlPort', 'Query'],
                 },
               },
               required: ['objectName'],

--- a/src/tools/mcp-tools.ts
+++ b/src/tools/mcp-tools.ts
@@ -97,7 +97,7 @@ NOTE: For documentation and code examples, use microsoft_docs_search or microsof
           }
           
           // Summary mode: just counts for fields/procedures
-          if (args.includeFields && obj.Type === 'Table') {
+          if (args.includeFields && (obj.Type === 'Table' || obj.Type === 'TableExtension')) {
             const fields = this.database.getTableFields(obj.Name);
             (enriched as any).FieldCount = fields.length;
             (enriched as any).Fields = fields.slice(0, 3); // Show first 3 fields
@@ -112,7 +112,7 @@ NOTE: For documentation and code examples, use microsoft_docs_search or microsof
           }
         } else {
           // Full mode - include everything but still apply reasonable limits
-          if (args.includeFields && obj.Type === 'Table') {
+          if (args.includeFields && (obj.Type === 'Table' || obj.Type === 'TableExtension')) {
             const fields = this.database.getTableFields(obj.Name);
             (enriched as any).Fields = fields.slice(0, 50); // Max 50 fields
             if (fields.length > 50) {
@@ -200,7 +200,7 @@ NOTE: For documentation and code examples, use microsoft_docs_search or microsof
       };
 
       // Add fields for tables
-      if (object.Type === 'Table' && (args.includeFields !== false)) {
+      if ((object.Type === 'Table' || object.Type === 'TableExtension') && (args.includeFields !== false)) {
         const allFields = this.database.getTableFields(object.Name);
         definition.Fields = allFields.slice(0, fieldLimit);
         if (allFields.length > fieldLimit) {
@@ -220,7 +220,7 @@ NOTE: For documentation and code examples, use microsoft_docs_search or microsof
       }
 
       // Add keys for tables
-      if (object.Type === 'Table' && (object as any).Keys) {
+      if ((object.Type === 'Table' || object.Type === 'TableExtension') && (object as any).Keys) {
         definition.Keys = (object as any).Keys;
       }
 
@@ -659,11 +659,11 @@ NOTE: For documentation and code examples, use microsoft_docs_search or microsof
       const includeDetails = args.includeDetails !== false;
       
       // Find the table
-      const objects = this.database.searchObjects(args.objectName, 'Table');
-      const targetTable = objects.find(obj => obj.Name === args.objectName);
-      
+      const objects = this.database.searchObjects(args.objectName);
+      const targetTable = objects.find(obj => obj.Name === args.objectName && (obj.Type === 'Table' || obj.Type === 'TableExtension'));
+
       if (!targetTable) {
-        throw new Error(`Table not found: ${args.objectName}`);
+        throw new Error(`Table or TableExtension not found: ${args.objectName}`);
       }
 
       // Get all fields for the table
@@ -732,11 +732,11 @@ NOTE: For documentation and code examples, use microsoft_docs_search or microsof
       const includeDetails = args.includeDetails !== false;
       
       // Find the page
-      const objects = this.database.searchObjects(args.objectName, 'Page');
-      const targetPage = objects.find(obj => obj.Name === args.objectName);
-      
+      const objects = this.database.searchObjects(args.objectName);
+      const targetPage = objects.find(obj => obj.Name === args.objectName && (obj.Type === 'Page' || obj.Type === 'PageExtension'));
+
       if (!targetPage) {
-        throw new Error(`Page not found: ${args.objectName}`);
+        throw new Error(`Page or PageExtension not found: ${args.objectName}`);
       }
 
       // Get all controls for the page
@@ -806,13 +806,13 @@ NOTE: For documentation and code examples, use microsoft_docs_search or microsof
       
       // Find the object (Report, Query, or XmlPort)
       const objects = this.database.searchObjects(args.objectName);
-      const targetObject = objects.find(obj => 
-        obj.Name === args.objectName && 
-        ['Report', 'Query', 'XmlPort'].includes(obj.Type)
+      const targetObject = objects.find(obj =>
+        obj.Name === args.objectName &&
+        ['Report', 'ReportExtension', 'Query', 'XmlPort'].includes(obj.Type)
       );
-      
+
       if (!targetObject) {
-        throw new Error(`Report/Query/XmlPort not found: ${args.objectName}`);
+        throw new Error(`Report/ReportExtension/Query/XmlPort not found: ${args.objectName}`);
       }
 
       // Get all data items for the object

--- a/tests/extension-objects.test.ts
+++ b/tests/extension-objects.test.ts
@@ -1,0 +1,614 @@
+import * as path from 'path';
+import { StreamingSymbolParser } from '../src/parser/streaming-parser';
+import { OptimizedSymbolDatabase } from '../src/core/symbol-database';
+import { ALObject, ALTable, ALEnum, ALReport } from '../src/types/al-types';
+
+/**
+ * Extension Objects Test Suite
+ *
+ * Tests that the AL MCP Server correctly parses and indexes extension objects
+ * (TableExtension, PageExtension, EnumExtensionType, ReportExtension) from
+ * compiled .app fixture files.
+ *
+ * Fixture apps:
+ *   - Base app: TestPublisher_Base Test App_1.0.0.0.app
+ *       Contains: Table "Test Item" (70000), Page "Test Item Card" (70000),
+ *       Codeunit "Test Item Mgmt" (70000), Enum "Test Status" (70000),
+ *       Report "Test Item List" (70000)
+ *
+ *   - Extension app: TestPublisher_Extension Test App_1.0.0.0.app
+ *       Contains: TableExtension "Test Item Ext" (70000) extending "Test Item",
+ *       PageExtension "Test Item Card Ext" (70000) extending "Test Item Card",
+ *       EnumExtensionType "Test Status Ext" (70000) extending "Test Status",
+ *       ReportExtension "Test Item List Ext" (70000) extending "Test Item List"
+ *
+ * NOTE: In the compiled SymbolReference.json, extension arrays use these keys:
+ *   - TableExtensions
+ *   - PageExtensions
+ *   - EnumExtensionTypes (NOT EnumExtensions -- this is the actual compiler output)
+ *   - ReportExtensions
+ *   - PermissionSetExtensions
+ *
+ * Extension objects have a TargetObject property (or Target for ReportExtensions)
+ * that identifies the base object being extended.
+ */
+
+const FIXTURES_DIR = path.resolve(__dirname, 'fixtures', 'compiled');
+const BASE_APP_PATH = path.join(FIXTURES_DIR, 'TestPublisher_Base Test App_1.0.0.0.app');
+const EXT_APP_PATH = path.join(FIXTURES_DIR, 'TestPublisher_Extension Test App_1.0.0.0.app');
+
+// ---------------------------------------------------------------------------
+// 1. Parser Tests
+// ---------------------------------------------------------------------------
+describe('StreamingSymbolParser - Extension Objects', () => {
+  let parser: StreamingSymbolParser;
+
+  beforeEach(() => {
+    parser = new StreamingSymbolParser();
+  });
+
+  // ---- Base app baseline ----
+
+  describe('Base app parsing (baseline)', () => {
+    it('should parse the base app and find 5 regular objects', async () => {
+      const objects = await parser.parseSymbolPackage(BASE_APP_PATH, 'Base Test App');
+
+      expect(objects.length).toBe(5);
+
+      const types = objects.map(o => o.Type).sort();
+      expect(types).toEqual(['Codeunit', 'Enum', 'Page', 'Report', 'Table']);
+    });
+
+    it('should parse Table "Test Item" with 4 fields', async () => {
+      const objects = await parser.parseSymbolPackage(BASE_APP_PATH, 'Base Test App');
+      const table = objects.find(o => o.Type === 'Table' && o.Name === 'Test Item') as ALTable | undefined;
+
+      expect(table).toBeDefined();
+      expect(table!.Id).toBe(70000);
+      expect(table!.Fields).toBeDefined();
+      expect(table!.Fields!.length).toBe(4);
+
+      const fieldNames = table!.Fields!.map(f => f.Name).sort();
+      expect(fieldNames).toEqual(['Blocked', 'Description', 'No.', 'Unit Price']);
+    });
+
+    it('should parse Enum "Test Status" with 3 values', async () => {
+      const objects = await parser.parseSymbolPackage(BASE_APP_PATH, 'Base Test App');
+      const enumObj = objects.find(o => o.Type === 'Enum' && o.Name === 'Test Status') as ALEnum | undefined;
+
+      expect(enumObj).toBeDefined();
+      expect(enumObj!.Id).toBe(70000);
+      expect(enumObj!.Values).toBeDefined();
+      expect(enumObj!.Values!.length).toBe(3);
+
+      const valueNames = enumObj!.Values!.map(v => v.Name).sort();
+      expect(valueNames).toEqual(['Active', 'Closed', 'New']);
+    });
+
+    it('should parse Report "Test Item List" with dataset columns', async () => {
+      const objects = await parser.parseSymbolPackage(BASE_APP_PATH, 'Base Test App');
+      const report = objects.find(o => o.Type === 'Report' && o.Name === 'Test Item List') as ALReport | undefined;
+
+      expect(report).toBeDefined();
+      expect(report!.Id).toBe(70000);
+      expect(report!.Dataset).toBeDefined();
+      expect(report!.Dataset!.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ---- Extension app parsing ----
+
+  describe('Extension app parsing', () => {
+    it('should parse the extension app and find extension objects', async () => {
+      const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
+
+      // BUG: Extension objects not parsed - the parser currently only handles
+      // regular object arrays (Tables, Pages, Codeunits, etc.) but does NOT
+      // handle extension arrays (TableExtensions, PageExtensions,
+      // EnumExtensionTypes, ReportExtensions). This test expects 4 extension
+      // objects once the parser is fixed.
+      expect(objects.length).toBe(4);
+    });
+
+    it('should parse TableExtension "Test Item Ext" with correct metadata', async () => {
+      const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
+      const tableExt = objects.find(
+        o => o.Type === 'TableExtension' && o.Name === 'Test Item Ext'
+      );
+
+      // BUG: Extension objects not parsed - should find TableExtension once fixed
+      expect(tableExt).toBeDefined();
+      expect(tableExt!.Id).toBe(70000);
+      expect(tableExt!.Type).toBe('TableExtension');
+    });
+
+    it('should parse TableExtension fields (Custom Category, Priority, Extended Status)', async () => {
+      const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
+      const tableExt = objects.find(
+        o => o.Type === 'TableExtension' && o.Name === 'Test Item Ext'
+      ) as (ALObject & { Fields?: any[] }) | undefined;
+
+      // BUG: Extension objects not parsed
+      expect(tableExt).toBeDefined();
+
+      // After parsing, the table extension should have 3 fields
+      expect(tableExt!.Fields).toBeDefined();
+      expect(tableExt!.Fields!.length).toBe(3);
+
+      const fieldNames = tableExt!.Fields!.map((f: any) => f.Name).sort();
+      expect(fieldNames).toEqual(['Custom Category', 'Extended Status', 'Priority']);
+    });
+
+    it('should parse PageExtension "Test Item Card Ext" with correct metadata', async () => {
+      const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
+      const pageExt = objects.find(
+        o => o.Type === 'PageExtension' && o.Name === 'Test Item Card Ext'
+      );
+
+      // BUG: Extension objects not parsed
+      expect(pageExt).toBeDefined();
+      expect(pageExt!.Id).toBe(70000);
+      expect(pageExt!.Type).toBe('PageExtension');
+    });
+
+    it('should parse EnumExtensionType "Test Status Ext" with correct metadata', async () => {
+      const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
+      const enumExt = objects.find(
+        o => o.Type === 'EnumExtensionType' && o.Name === 'Test Status Ext'
+      );
+
+      // BUG: Extension objects not parsed - note the type is EnumExtensionType
+      // (matching the SymbolReference.json key "EnumExtensionTypes")
+      expect(enumExt).toBeDefined();
+      expect(enumExt!.Id).toBe(70000);
+      expect(enumExt!.Type).toBe('EnumExtensionType');
+    });
+
+    it('should parse EnumExtensionType values (Pending Review, Archived)', async () => {
+      const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
+      const enumExt = objects.find(
+        o => o.Type === 'EnumExtensionType' && o.Name === 'Test Status Ext'
+      ) as (ALObject & { Values?: any[] }) | undefined;
+
+      // BUG: Extension objects not parsed
+      expect(enumExt).toBeDefined();
+      expect(enumExt!.Values).toBeDefined();
+      expect(enumExt!.Values!.length).toBe(2);
+
+      const valueNames = enumExt!.Values!.map((v: any) => v.Name).sort();
+      expect(valueNames).toEqual(['Archived', 'Pending Review']);
+    });
+
+    it('should parse ReportExtension "Test Item List Ext" with correct metadata', async () => {
+      const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
+      const reportExt = objects.find(
+        o => o.Type === 'ReportExtension' && o.Name === 'Test Item List Ext'
+      );
+
+      // BUG: Extension objects not parsed
+      expect(reportExt).toBeDefined();
+      expect(reportExt!.Id).toBe(70000);
+      expect(reportExt!.Type).toBe('ReportExtension');
+    });
+
+    it('should set the Extends property from TargetObject for table/page/enum extensions', async () => {
+      const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
+
+      // TableExtension should record that it extends "Test Item"
+      const tableExt = objects.find(o => o.Type === 'TableExtension');
+      expect(tableExt).toBeDefined();
+      const tableExtends = tableExt!.Properties?.find(p => p.Name === 'Extends');
+      expect(tableExtends).toBeDefined();
+      expect(tableExtends!.Value).toBe('Test Item');
+
+      // PageExtension should record that it extends "Test Item Card"
+      const pageExt = objects.find(o => o.Type === 'PageExtension');
+      expect(pageExt).toBeDefined();
+      const pageExtends = pageExt!.Properties?.find(p => p.Name === 'Extends');
+      expect(pageExtends).toBeDefined();
+      expect(pageExtends!.Value).toBe('Test Item Card');
+
+      // EnumExtensionType should record that it extends "Test Status"
+      const enumExt = objects.find(o => o.Type === 'EnumExtensionType');
+      expect(enumExt).toBeDefined();
+      const enumExtends = enumExt!.Properties?.find(p => p.Name === 'Extends');
+      expect(enumExtends).toBeDefined();
+      expect(enumExtends!.Value).toBe('Test Status');
+    });
+
+    it('should set the Extends property from Target for report extensions', async () => {
+      const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
+
+      // ReportExtension should record that it extends "Test Item List"
+      const reportExt = objects.find(o => o.Type === 'ReportExtension');
+      expect(reportExt).toBeDefined();
+      const reportExtends = reportExt!.Properties?.find(p => p.Name === 'Extends');
+      expect(reportExtends).toBeDefined();
+      expect(reportExtends!.Value).toBe('Test Item List');
+    });
+
+    it('should assign PackageName to all parsed extension objects', async () => {
+      const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
+
+      // BUG: Extension objects not parsed - when fixed, every object should
+      // carry the package name
+      expect(objects.length).toBeGreaterThan(0);
+      for (const obj of objects) {
+        expect(obj.PackageName).toBe('Extension Test App');
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Database Indexing Tests
+// ---------------------------------------------------------------------------
+describe('OptimizedSymbolDatabase - Extension Object Indexing', () => {
+  let database: OptimizedSymbolDatabase;
+
+  beforeEach(() => {
+    database = new OptimizedSymbolDatabase();
+  });
+
+  describe('Manual addObject for extension types', () => {
+    it('should index a TableExtension object and retrieve it by type', () => {
+      const tableExt: ALObject = {
+        Id: 70000,
+        Name: 'Test Item Ext',
+        Type: 'TableExtension',
+        Properties: [{ Name: 'Extends', Value: 'Test Item' }],
+      };
+
+      database.addObject(tableExt, 'Extension Test App');
+
+      const results = database.getObjectsByType('TableExtension');
+      expect(results).toHaveLength(1);
+      expect(results[0].Name).toBe('Test Item Ext');
+    });
+
+    it('should index a PageExtension object and retrieve it by name', () => {
+      const pageExt: ALObject = {
+        Id: 70000,
+        Name: 'Test Item Card Ext',
+        Type: 'PageExtension',
+        Properties: [{ Name: 'Extends', Value: 'Test Item Card' }],
+      };
+
+      database.addObject(pageExt, 'Extension Test App');
+
+      const results = database.getObjectsByName('Test Item Card Ext');
+      expect(results).toHaveLength(1);
+      expect(results[0].Type).toBe('PageExtension');
+    });
+
+    it('should index an EnumExtensionType object and retrieve it by ID', () => {
+      const enumExt: ALObject = {
+        Id: 70000,
+        Name: 'Test Status Ext',
+        Type: 'EnumExtensionType',
+        Properties: [{ Name: 'Extends', Value: 'Test Status' }],
+      };
+
+      database.addObject(enumExt, 'Extension Test App');
+
+      const result = database.getObjectById('EnumExtensionType:70000');
+      expect(result).toBeDefined();
+      expect(result!.Name).toBe('Test Status Ext');
+    });
+
+    it('should index a ReportExtension object and retrieve it by search', () => {
+      const reportExt: ALObject = {
+        Id: 70000,
+        Name: 'Test Item List Ext',
+        Type: 'ReportExtension',
+        Properties: [{ Name: 'Extends', Value: 'Test Item List' }],
+      };
+
+      database.addObject(reportExt, 'Extension Test App');
+
+      const results = database.searchObjects('Test Item List Ext');
+      expect(results).toHaveLength(1);
+      expect(results[0].Type).toBe('ReportExtension');
+    });
+
+    it('should track extension-to-base relationship via Extends property', () => {
+      const baseTable: ALObject = {
+        Id: 70000,
+        Name: 'Test Item',
+        Type: 'Table',
+        Properties: [],
+      };
+      const tableExt: ALObject = {
+        Id: 70000,
+        Name: 'Test Item Ext',
+        Type: 'TableExtension',
+        Properties: [{ Name: 'Extends', Value: 'Test Item' }],
+      };
+
+      database.addObject(baseTable, 'Base Test App');
+      database.addObject(tableExt, 'Extension Test App');
+
+      const extensions = database.getExtensions('Test Item');
+      expect(extensions).toHaveLength(1);
+      expect(extensions[0].Name).toBe('Test Item Ext');
+      expect(extensions[0].Type).toBe('TableExtension');
+    });
+
+    it('should return extensions via findReferences with referenceType "extends"', () => {
+      const baseTable: ALObject = {
+        Id: 70000,
+        Name: 'Test Item',
+        Type: 'Table',
+        Properties: [],
+      };
+      const tableExt: ALObject = {
+        Id: 70000,
+        Name: 'Test Item Ext',
+        Type: 'TableExtension',
+        Properties: [{ Name: 'Extends', Value: 'Test Item' }],
+      };
+
+      database.addObject(baseTable, 'Base Test App');
+      database.addObject(tableExt, 'Extension Test App');
+
+      const refs = database.findReferences('Test Item', 'extends');
+      expect(refs).toHaveLength(1);
+      expect(refs[0].sourceName).toBe('Test Item Ext');
+      expect(refs[0].sourceType).toBe('TableExtension');
+      expect(refs[0].referenceType).toBe('extends');
+    });
+
+    it('should index TableExtension fields via getTableFields', () => {
+      // The database currently indexes fields only for Type === 'Table'.
+      // For extension fields to be accessible through getTableFields,
+      // the indexing logic needs to handle TableExtension as well.
+      const tableExt: ALObject & { Fields?: any[] } = {
+        Id: 70000,
+        Name: 'Test Item Ext',
+        Type: 'TableExtension',
+        Properties: [{ Name: 'Extends', Value: 'Test Item' }],
+        Fields: [
+          { Id: 70000, Name: 'Custom Category', TypeDefinition: { Name: 'Text', Length: 50 }, Properties: [] },
+          { Id: 70001, Name: 'Priority', TypeDefinition: { Name: 'Integer' }, Properties: [] },
+          { Id: 70002, Name: 'Extended Status', TypeDefinition: { Name: 'Enum' }, Properties: [] },
+        ],
+      };
+
+      database.addObject(tableExt as ALObject, 'Extension Test App');
+
+      // BUG: indexTypeSpecificData only indexes fields for Type === 'Table',
+      // not 'TableExtension'. After the fix, extension fields should be
+      // accessible via getTableFields using the extension object's name.
+      const fields = database.getTableFields('Test Item Ext');
+      expect(fields).toHaveLength(3);
+      expect(fields.map(f => f.Name).sort()).toEqual([
+        'Custom Category',
+        'Extended Status',
+        'Priority',
+      ]);
+    });
+
+    it('should include extension types in statistics', () => {
+      const objects: ALObject[] = [
+        { Id: 70000, Name: 'Test Item', Type: 'Table', Properties: [] },
+        { Id: 70000, Name: 'Test Item Ext', Type: 'TableExtension', Properties: [{ Name: 'Extends', Value: 'Test Item' }] },
+        { Id: 70000, Name: 'Test Item Card Ext', Type: 'PageExtension', Properties: [{ Name: 'Extends', Value: 'Test Item Card' }] },
+        { Id: 70000, Name: 'Test Status Ext', Type: 'EnumExtensionType', Properties: [{ Name: 'Extends', Value: 'Test Status' }] },
+        { Id: 70000, Name: 'Test Item List Ext', Type: 'ReportExtension', Properties: [{ Name: 'Extends', Value: 'Test Item List' }] },
+      ];
+
+      objects.forEach(o => database.addObject(o, 'Test'));
+
+      const stats = database.getStatistics();
+      expect(stats.totalObjects).toBe(5);
+      expect(stats.objectsByType.get('Table')).toBe(1);
+      expect(stats.objectsByType.get('TableExtension')).toBe(1);
+      expect(stats.objectsByType.get('PageExtension')).toBe(1);
+      expect(stats.objectsByType.get('EnumExtensionType')).toBe(1);
+      expect(stats.objectsByType.get('ReportExtension')).toBe(1);
+    });
+
+    it('should allow filtering search results by extension type', () => {
+      const objects: ALObject[] = [
+        { Id: 70000, Name: 'Test Item', Type: 'Table', Properties: [] },
+        { Id: 70000, Name: 'Test Item Ext', Type: 'TableExtension', Properties: [{ Name: 'Extends', Value: 'Test Item' }] },
+      ];
+
+      objects.forEach(o => database.addObject(o, 'Test'));
+
+      const allResults = database.searchObjects('Test Item');
+      expect(allResults.length).toBe(2);
+
+      const extensionsOnly = database.searchObjects('Test Item', 'TableExtension');
+      expect(extensionsOnly.length).toBe(1);
+      expect(extensionsOnly[0].Type).toBe('TableExtension');
+
+      const tablesOnly = database.searchObjects('Test Item', 'Table');
+      expect(tablesOnly.length).toBe(1);
+      expect(tablesOnly[0].Type).toBe('Table');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Integration Tests - Full Pipeline (Parser -> Database)
+// ---------------------------------------------------------------------------
+describe('Integration - Extension Objects End-to-End', () => {
+  let parser: StreamingSymbolParser;
+  let database: OptimizedSymbolDatabase;
+
+  beforeAll(async () => {
+    parser = new StreamingSymbolParser();
+    database = new OptimizedSymbolDatabase();
+
+    // Load both packages into the database
+    const baseObjects = await parser.parseSymbolPackage(BASE_APP_PATH, 'Base Test App');
+    baseObjects.forEach(obj => database.addObject(obj, 'Base Test App'));
+
+    const extObjects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
+    extObjects.forEach(obj => database.addObject(obj, 'Extension Test App'));
+
+    database.buildOptimizedIndices();
+  });
+
+  describe('Total object count', () => {
+    it('should include both base and extension objects in the total count', () => {
+      const stats = database.getStatistics();
+
+      // Base app: 5 objects (Table, Page, Codeunit, Enum, Report)
+      // Extension app: 4 extensions (TableExtension, PageExtension,
+      //   EnumExtensionType, ReportExtension)
+      // BUG: If extensions are not parsed, total will be only 5
+      expect(stats.totalObjects).toBe(9);
+    });
+  });
+
+  describe('Extension-to-base relationships', () => {
+    it('should find TableExtension via getExtensions("Test Item")', () => {
+      const extensions = database.getExtensions('Test Item');
+
+      // BUG: If extensions are not parsed, this will be empty
+      expect(extensions.length).toBeGreaterThanOrEqual(1);
+
+      const tableExt = extensions.find(e => e.Type === 'TableExtension');
+      expect(tableExt).toBeDefined();
+      expect(tableExt!.Name).toBe('Test Item Ext');
+    });
+
+    it('should find PageExtension via getExtensions("Test Item Card")', () => {
+      const extensions = database.getExtensions('Test Item Card');
+
+      expect(extensions.length).toBeGreaterThanOrEqual(1);
+
+      const pageExt = extensions.find(e => e.Type === 'PageExtension');
+      expect(pageExt).toBeDefined();
+      expect(pageExt!.Name).toBe('Test Item Card Ext');
+    });
+
+    it('should find EnumExtensionType via getExtensions("Test Status")', () => {
+      const extensions = database.getExtensions('Test Status');
+
+      expect(extensions.length).toBeGreaterThanOrEqual(1);
+
+      const enumExt = extensions.find(e => e.Type === 'EnumExtensionType');
+      expect(enumExt).toBeDefined();
+      expect(enumExt!.Name).toBe('Test Status Ext');
+    });
+
+    it('should find ReportExtension via getExtensions("Test Item List")', () => {
+      const extensions = database.getExtensions('Test Item List');
+
+      expect(extensions.length).toBeGreaterThanOrEqual(1);
+
+      const reportExt = extensions.find(e => e.Type === 'ReportExtension');
+      expect(reportExt).toBeDefined();
+      expect(reportExt!.Name).toBe('Test Item List Ext');
+    });
+  });
+
+  describe('Type-based queries across both packages', () => {
+    it('should list all TableExtension objects', () => {
+      const tableExts = database.getObjectsByType('TableExtension');
+      expect(tableExts.length).toBeGreaterThanOrEqual(1);
+      expect(tableExts.some(o => o.Name === 'Test Item Ext')).toBe(true);
+    });
+
+    it('should list all PageExtension objects', () => {
+      const pageExts = database.getObjectsByType('PageExtension');
+      expect(pageExts.length).toBeGreaterThanOrEqual(1);
+      expect(pageExts.some(o => o.Name === 'Test Item Card Ext')).toBe(true);
+    });
+
+    it('should list all EnumExtensionType objects', () => {
+      const enumExts = database.getObjectsByType('EnumExtensionType');
+      expect(enumExts.length).toBeGreaterThanOrEqual(1);
+      expect(enumExts.some(o => o.Name === 'Test Status Ext')).toBe(true);
+    });
+
+    it('should list all ReportExtension objects', () => {
+      const reportExts = database.getObjectsByType('ReportExtension');
+      expect(reportExts.length).toBeGreaterThanOrEqual(1);
+      expect(reportExts.some(o => o.Name === 'Test Item List Ext')).toBe(true);
+    });
+  });
+
+  describe('Statistics include extension types', () => {
+    it('should report extension type counts in objectsByType', () => {
+      const stats = database.getStatistics();
+
+      // BUG: If extensions not parsed, these will be undefined
+      expect(stats.objectsByType.get('TableExtension')).toBe(1);
+      expect(stats.objectsByType.get('PageExtension')).toBe(1);
+      expect(stats.objectsByType.get('EnumExtensionType')).toBe(1);
+      expect(stats.objectsByType.get('ReportExtension')).toBe(1);
+
+      // Base types should still be present
+      expect(stats.objectsByType.get('Table')).toBe(1);
+      expect(stats.objectsByType.get('Page')).toBe(1);
+      expect(stats.objectsByType.get('Codeunit')).toBe(1);
+      expect(stats.objectsByType.get('Enum')).toBe(1);
+      expect(stats.objectsByType.get('Report')).toBe(1);
+    });
+
+    it('should report 2 packages', () => {
+      const stats = database.getStatistics();
+      expect(stats.packages).toBe(2);
+    });
+  });
+
+  describe('Package summary', () => {
+    it('should show correct object counts per package', () => {
+      const summary = database.getPackageSummary();
+
+      expect(summary.get('Base Test App')).toBe(5);
+      // BUG: If extensions not parsed, Extension Test App will have 0 objects
+      expect(summary.get('Extension Test App')).toBe(4);
+    });
+  });
+
+  describe('Cross-package search', () => {
+    it('should find both base and extension objects when searching by name pattern', () => {
+      const results = database.searchObjects('Test Item*');
+
+      // Should find: "Test Item", "Test Item Card", "Test Item Mgmt",
+      //              "Test Item Ext", "Test Item Card Ext",
+      //              "Test Item List", "Test Item List Ext"
+      const names = results.map(r => r.Name).sort();
+      expect(names).toContain('Test Item');
+      expect(names).toContain('Test Item Ext');
+      expect(names).toContain('Test Item Card Ext');
+      expect(names).toContain('Test Item List Ext');
+    });
+
+    it('should filter extension objects by package name', () => {
+      const extOnly = database.searchObjects('*', undefined, 'Extension Test App');
+
+      // BUG: If extensions not parsed, this will be empty
+      expect(extOnly.length).toBe(4);
+      for (const obj of extOnly) {
+        expect(obj.PackageName).toBe('Extension Test App');
+      }
+    });
+  });
+
+  describe('findReferences integration', () => {
+    it('should find "extends" references from extension to base for "Test Item"', () => {
+      const refs = database.findReferences('Test Item', 'extends');
+
+      expect(refs.length).toBeGreaterThanOrEqual(1);
+      const tableExtRef = refs.find(r => r.sourceName === 'Test Item Ext');
+      expect(tableExtRef).toBeDefined();
+      expect(tableExtRef!.referenceType).toBe('extends');
+    });
+
+    it('should find all reference types for "Test Item" (extends + source_table + others)', () => {
+      const allRefs = database.findReferences('Test Item');
+
+      // TableExtension "extends" is expected; source_table uses ID not name in compiled symbols
+      expect(allRefs.length).toBeGreaterThanOrEqual(1);
+
+      const refTypes = allRefs.map(r => r.referenceType);
+      expect(refTypes).toContain('extends');
+    });
+  });
+});

--- a/tests/extension-objects.test.ts
+++ b/tests/extension-objects.test.ts
@@ -111,11 +111,6 @@ describeOrSkip('StreamingSymbolParser - Extension Objects', () => {
     it('should parse the extension app and find extension objects', async () => {
       const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
 
-      // BUG: Extension objects not parsed - the parser currently only handles
-      // regular object arrays (Tables, Pages, Codeunits, etc.) but does NOT
-      // handle extension arrays (TableExtensions, PageExtensions,
-      // EnumExtensionTypes, ReportExtensions). This test expects 4 extension
-      // objects once the parser is fixed.
       expect(objects.length).toBe(4);
     });
 
@@ -125,7 +120,6 @@ describeOrSkip('StreamingSymbolParser - Extension Objects', () => {
         o => o.Type === 'TableExtension' && o.Name === 'Test Item Ext'
       );
 
-      // BUG: Extension objects not parsed - should find TableExtension once fixed
       expect(tableExt).toBeDefined();
       expect(tableExt!.Id).toBe(70000);
       expect(tableExt!.Type).toBe('TableExtension');
@@ -137,7 +131,6 @@ describeOrSkip('StreamingSymbolParser - Extension Objects', () => {
         o => o.Type === 'TableExtension' && o.Name === 'Test Item Ext'
       ) as (ALObject & { Fields?: any[] }) | undefined;
 
-      // BUG: Extension objects not parsed
       expect(tableExt).toBeDefined();
 
       // After parsing, the table extension should have 3 fields
@@ -154,7 +147,6 @@ describeOrSkip('StreamingSymbolParser - Extension Objects', () => {
         o => o.Type === 'PageExtension' && o.Name === 'Test Item Card Ext'
       );
 
-      // BUG: Extension objects not parsed
       expect(pageExt).toBeDefined();
       expect(pageExt!.Id).toBe(70000);
       expect(pageExt!.Type).toBe('PageExtension');
@@ -166,8 +158,6 @@ describeOrSkip('StreamingSymbolParser - Extension Objects', () => {
         o => o.Type === 'EnumExtensionType' && o.Name === 'Test Status Ext'
       );
 
-      // BUG: Extension objects not parsed - note the type is EnumExtensionType
-      // (matching the SymbolReference.json key "EnumExtensionTypes")
       expect(enumExt).toBeDefined();
       expect(enumExt!.Id).toBe(70000);
       expect(enumExt!.Type).toBe('EnumExtensionType');
@@ -179,7 +169,6 @@ describeOrSkip('StreamingSymbolParser - Extension Objects', () => {
         o => o.Type === 'EnumExtensionType' && o.Name === 'Test Status Ext'
       ) as (ALObject & { Values?: any[] }) | undefined;
 
-      // BUG: Extension objects not parsed
       expect(enumExt).toBeDefined();
       expect(enumExt!.Values).toBeDefined();
       expect(enumExt!.Values!.length).toBe(2);
@@ -194,7 +183,6 @@ describeOrSkip('StreamingSymbolParser - Extension Objects', () => {
         o => o.Type === 'ReportExtension' && o.Name === 'Test Item List Ext'
       );
 
-      // BUG: Extension objects not parsed
       expect(reportExt).toBeDefined();
       expect(reportExt!.Id).toBe(70000);
       expect(reportExt!.Type).toBe('ReportExtension');
@@ -239,8 +227,6 @@ describeOrSkip('StreamingSymbolParser - Extension Objects', () => {
     it('should assign PackageName to all parsed extension objects', async () => {
       const objects = await parser.parseSymbolPackage(EXT_APP_PATH, 'Extension Test App');
 
-      // BUG: Extension objects not parsed - when fixed, every object should
-      // carry the package name
       expect(objects.length).toBeGreaterThan(0);
       for (const obj of objects) {
         expect(obj.PackageName).toBe('Extension Test App');
@@ -385,9 +371,6 @@ describe('OptimizedSymbolDatabase - Extension Object Indexing', () => {
 
       database.addObject(tableExt as ALObject, 'Extension Test App');
 
-      // BUG: indexTypeSpecificData only indexes fields for Type === 'Table',
-      // not 'TableExtension'. After the fix, extension fields should be
-      // accessible via getTableFields using the extension object's name.
       const fields = database.getTableFields('Test Item Ext');
       expect(fields).toHaveLength(3);
       expect(fields.map(f => f.Name).sort()).toEqual([
@@ -467,7 +450,6 @@ describeOrSkip('Integration - Extension Objects End-to-End', () => {
       // Base app: 5 objects (Table, Page, Codeunit, Enum, Report)
       // Extension app: 4 extensions (TableExtension, PageExtension,
       //   EnumExtensionType, ReportExtension)
-      // BUG: If extensions are not parsed, total will be only 5
       expect(stats.totalObjects).toBe(9);
     });
   });
@@ -476,7 +458,6 @@ describeOrSkip('Integration - Extension Objects End-to-End', () => {
     it('should find TableExtension via getExtensions("Test Item")', () => {
       const extensions = database.getExtensions('Test Item');
 
-      // BUG: If extensions are not parsed, this will be empty
       expect(extensions.length).toBeGreaterThanOrEqual(1);
 
       const tableExt = extensions.find(e => e.Type === 'TableExtension');
@@ -545,7 +526,6 @@ describeOrSkip('Integration - Extension Objects End-to-End', () => {
     it('should report extension type counts in objectsByType', () => {
       const stats = database.getStatistics();
 
-      // BUG: If extensions not parsed, these will be undefined
       expect(stats.objectsByType.get('TableExtension')).toBe(1);
       expect(stats.objectsByType.get('PageExtension')).toBe(1);
       expect(stats.objectsByType.get('EnumExtensionType')).toBe(1);
@@ -570,7 +550,6 @@ describeOrSkip('Integration - Extension Objects End-to-End', () => {
       const summary = database.getPackageSummary();
 
       expect(summary.get('Base Test App')).toBe(5);
-      // BUG: If extensions not parsed, Extension Test App will have 0 objects
       expect(summary.get('Extension Test App')).toBe(4);
     });
   });
@@ -592,7 +571,6 @@ describeOrSkip('Integration - Extension Objects End-to-End', () => {
     it('should filter extension objects by package name', () => {
       const extOnly = database.searchObjects('*', undefined, 'Extension Test App');
 
-      // BUG: If extensions not parsed, this will be empty
       expect(extOnly.length).toBe(4);
       for (const obj of extOnly) {
         expect(obj.PackageName).toBe('Extension Test App');

--- a/tests/extension-objects.test.ts
+++ b/tests/extension-objects.test.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as fs from 'fs';
 import { StreamingSymbolParser } from '../src/parser/streaming-parser';
 import { OptimizedSymbolDatabase } from '../src/core/symbol-database';
 import { ALObject, ALTable, ALEnum, ALReport } from '../src/types/al-types';
@@ -9,6 +10,10 @@ import { ALObject, ALTable, ALEnum, ALReport } from '../src/types/al-types';
  * Tests that the AL MCP Server correctly parses and indexes extension objects
  * (TableExtension, PageExtension, EnumExtensionType, ReportExtension) from
  * compiled .app fixture files.
+ *
+ * Fixture apps are compiled on demand by the Jest globalSetup script
+ * (tests/fixtures/compile-fixtures.ts). If the AL CLI is not available,
+ * these tests are skipped gracefully.
  *
  * Fixture apps:
  *   - Base app: TestPublisher_Base Test App_1.0.0.0.app
@@ -37,10 +42,14 @@ const FIXTURES_DIR = path.resolve(__dirname, 'fixtures', 'compiled');
 const BASE_APP_PATH = path.join(FIXTURES_DIR, 'TestPublisher_Base Test App_1.0.0.0.app');
 const EXT_APP_PATH = path.join(FIXTURES_DIR, 'TestPublisher_Extension Test App_1.0.0.0.app');
 
+// Skip entire file if compiled fixtures are not available (AL CLI missing)
+const fixturesAvailable = fs.existsSync(BASE_APP_PATH) && fs.existsSync(EXT_APP_PATH);
+const describeOrSkip = fixturesAvailable ? describe : describe.skip;
+
 // ---------------------------------------------------------------------------
 // 1. Parser Tests
 // ---------------------------------------------------------------------------
-describe('StreamingSymbolParser - Extension Objects', () => {
+describeOrSkip('StreamingSymbolParser - Extension Objects', () => {
   let parser: StreamingSymbolParser;
 
   beforeEach(() => {
@@ -433,7 +442,7 @@ describe('OptimizedSymbolDatabase - Extension Object Indexing', () => {
 // ---------------------------------------------------------------------------
 // 3. Integration Tests - Full Pipeline (Parser -> Database)
 // ---------------------------------------------------------------------------
-describe('Integration - Extension Objects End-to-End', () => {
+describeOrSkip('Integration - Extension Objects End-to-End', () => {
   let parser: StreamingSymbolParser;
   let database: OptimizedSymbolDatabase;
 

--- a/tests/fixtures/base-app/app.json
+++ b/tests/fixtures/base-app/app.json
@@ -1,0 +1,10 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "name": "Base Test App",
+  "publisher": "TestPublisher",
+  "version": "1.0.0.0",
+  "runtime": "14.0",
+  "target": "Cloud",
+  "features": ["NoImplicitWith"],
+  "dependencies": []
+}

--- a/tests/fixtures/base-app/src/TestCodeunit.Codeunit.al
+++ b/tests/fixtures/base-app/src/TestCodeunit.Codeunit.al
@@ -1,0 +1,21 @@
+codeunit 70000 "Test Item Mgmt"
+{
+    procedure GetItemDescription(ItemNo: Code[20]): Text[100]
+    var
+        TestItem: Record "Test Item";
+    begin
+        if TestItem.Get(ItemNo) then
+            exit(TestItem.Description);
+        exit('');
+    end;
+
+    procedure SetItemBlocked(ItemNo: Code[20]; NewBlocked: Boolean)
+    var
+        TestItem: Record "Test Item";
+    begin
+        if TestItem.Get(ItemNo) then begin
+            TestItem.Blocked := NewBlocked;
+            TestItem.Modify(true);
+        end;
+    end;
+}

--- a/tests/fixtures/base-app/src/TestEnum.Enum.al
+++ b/tests/fixtures/base-app/src/TestEnum.Enum.al
@@ -1,0 +1,17 @@
+enum 70000 "Test Status"
+{
+    Extensible = true;
+
+    value(0; "New")
+    {
+        Caption = 'New';
+    }
+    value(1; "Active")
+    {
+        Caption = 'Active';
+    }
+    value(2; "Closed")
+    {
+        Caption = 'Closed';
+    }
+}

--- a/tests/fixtures/base-app/src/TestPage.Page.al
+++ b/tests/fixtures/base-app/src/TestPage.Page.al
@@ -1,0 +1,32 @@
+page 70000 "Test Item Card"
+{
+    PageType = Card;
+    SourceTable = "Test Item";
+    Caption = 'Test Item Card';
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                field("No."; Rec."No.")
+                {
+                    ApplicationArea = All;
+                }
+                field(Description; Rec.Description)
+                {
+                    ApplicationArea = All;
+                }
+                field("Unit Price"; Rec."Unit Price")
+                {
+                    ApplicationArea = All;
+                }
+                field(Blocked; Rec.Blocked)
+                {
+                    ApplicationArea = All;
+                }
+            }
+        }
+    }
+}

--- a/tests/fixtures/base-app/src/TestReport.Report.al
+++ b/tests/fixtures/base-app/src/TestReport.Report.al
@@ -1,0 +1,21 @@
+report 70000 "Test Item List"
+{
+    Caption = 'Test Item List';
+    DefaultLayout = RDLC;
+
+    dataset
+    {
+        dataitem(TestItem; "Test Item")
+        {
+            column(No; "No.")
+            {
+            }
+            column(Description; Description)
+            {
+            }
+            column(UnitPrice; "Unit Price")
+            {
+            }
+        }
+    }
+}

--- a/tests/fixtures/base-app/src/TestTable.Table.al
+++ b/tests/fixtures/base-app/src/TestTable.Table.al
@@ -1,0 +1,36 @@
+table 70000 "Test Item"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            Caption = 'No.';
+        }
+        field(2; "Description"; Text[100])
+        {
+            Caption = 'Description';
+        }
+        field(3; "Unit Price"; Decimal)
+        {
+            Caption = 'Unit Price';
+        }
+        field(4; "Blocked"; Boolean)
+        {
+            Caption = 'Blocked';
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+
+    trigger OnInsert()
+    begin
+    end;
+}

--- a/tests/fixtures/compile-fixtures.ts
+++ b/tests/fixtures/compile-fixtures.ts
@@ -1,0 +1,130 @@
+/**
+ * Jest Global Setup: Compile AL test fixtures on demand
+ *
+ * This script runs once before all test suites. It checks if the compiled
+ * .app symbol packages exist in tests/fixtures/compiled/ and compiles them
+ * from the AL source projects if missing.
+ *
+ * Requires the AL CLI (installed via dotnet tool). If AL is not available,
+ * compilation is skipped and tests that need fixtures will skip gracefully.
+ */
+
+import { spawn } from 'child_process';
+import * as path from 'path';
+import { promises as fs } from 'fs';
+import { ALInstaller } from '../../src/cli/al-installer';
+
+const FIXTURES_DIR = path.resolve(__dirname);
+const COMPILED_DIR = path.join(FIXTURES_DIR, 'compiled');
+const BASE_APP_DIR = path.join(FIXTURES_DIR, 'base-app');
+const EXT_APP_DIR = path.join(FIXTURES_DIR, 'ext-app');
+
+const BASE_APP_OUTPUT = path.join(COMPILED_DIR, 'TestPublisher_Base Test App_1.0.0.0.app');
+const EXT_APP_OUTPUT = path.join(COMPILED_DIR, 'TestPublisher_Extension Test App_1.0.0.0.app');
+
+function execAL(alPath: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(alPath, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout?.on('data', (data) => { stdout += data.toString(); });
+    proc.stderr?.on('data', (data) => { stderr += data.toString(); });
+
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new Error(`AL command failed (exit ${code}): ${stderr || stdout}`));
+      }
+    });
+
+    proc.on('error', (error) => {
+      reject(new Error(`Failed to spawn AL: ${error.message}`));
+    });
+
+    setTimeout(() => {
+      proc.kill('SIGTERM');
+      reject(new Error('AL command timed out after 60s'));
+    }, 60000);
+  });
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function compileFixtures(): Promise<void> {
+  // Check if compiled files already exist
+  if (await fileExists(BASE_APP_OUTPUT) && await fileExists(EXT_APP_OUTPUT)) {
+    return;
+  }
+
+  console.log('[compile-fixtures] Compiled fixtures missing, attempting to build...');
+
+  // Ensure AL CLI is available
+  const installer = new ALInstaller();
+  const result = await installer.ensureALAvailable();
+
+  if (!result.success) {
+    console.warn(`[compile-fixtures] AL CLI not available: ${result.message}`);
+    console.warn('[compile-fixtures] Extension object tests will be skipped.');
+    return;
+  }
+
+  const alPath = result.alPath!;
+  console.log(`[compile-fixtures] Using AL CLI: ${result.message}`);
+
+  // Create output directory
+  await fs.mkdir(COMPILED_DIR, { recursive: true });
+
+  // Ensure .alpackages directories exist
+  await fs.mkdir(path.join(BASE_APP_DIR, '.alpackages'), { recursive: true });
+  await fs.mkdir(path.join(EXT_APP_DIR, '.alpackages'), { recursive: true });
+
+  // Step 1: Compile base app
+  console.log('[compile-fixtures] Compiling base app...');
+  const baseRawApp = path.join(COMPILED_DIR, 'base-raw.app');
+  await execAL(alPath, [
+    'compile',
+    `/project:${BASE_APP_DIR}`,
+    `/packagecachepath:${path.join(BASE_APP_DIR, '.alpackages')}`,
+    `/out:${baseRawApp}`
+  ]);
+
+  // Step 2: Create symbol package from base app
+  console.log('[compile-fixtures] Creating base app symbol package...');
+  await execAL(alPath, ['CreateSymbolPackage', baseRawApp, BASE_APP_OUTPUT]);
+
+  // Step 3: Copy base app symbol package to ext-app's .alpackages (it depends on it)
+  await fs.copyFile(BASE_APP_OUTPUT, path.join(EXT_APP_DIR, '.alpackages', path.basename(BASE_APP_OUTPUT)));
+
+  // Step 4: Compile extension app
+  console.log('[compile-fixtures] Compiling extension app...');
+  const extRawApp = path.join(COMPILED_DIR, 'ext-raw.app');
+  await execAL(alPath, [
+    'compile',
+    `/project:${EXT_APP_DIR}`,
+    `/packagecachepath:${path.join(EXT_APP_DIR, '.alpackages')}`,
+    `/out:${extRawApp}`
+  ]);
+
+  // Step 5: Create symbol package from extension app
+  console.log('[compile-fixtures] Creating extension app symbol package...');
+  await execAL(alPath, ['CreateSymbolPackage', extRawApp, EXT_APP_OUTPUT]);
+
+  // Clean up intermediate raw .app files
+  await fs.unlink(baseRawApp).catch(() => {});
+  await fs.unlink(extRawApp).catch(() => {});
+
+  console.log('[compile-fixtures] Fixture compilation complete.');
+}
+
+export default async function globalSetup(): Promise<void> {
+  await compileFixtures();
+}

--- a/tests/fixtures/ext-app/app.json
+++ b/tests/fixtures/ext-app/app.json
@@ -1,0 +1,17 @@
+{
+  "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "name": "Extension Test App",
+  "publisher": "TestPublisher",
+  "version": "1.0.0.0",
+  "runtime": "14.0",
+  "target": "Cloud",
+  "features": ["NoImplicitWith"],
+  "dependencies": [
+    {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "name": "Base Test App",
+      "publisher": "TestPublisher",
+      "version": "1.0.0.0"
+    }
+  ]
+}

--- a/tests/fixtures/ext-app/src/TestEnumExt.EnumExtension.al
+++ b/tests/fixtures/ext-app/src/TestEnumExt.EnumExtension.al
@@ -1,0 +1,11 @@
+enumextension 70000 "Test Status Ext" extends "Test Status"
+{
+    value(100; "Pending Review")
+    {
+        Caption = 'Pending Review';
+    }
+    value(101; "Archived")
+    {
+        Caption = 'Archived';
+    }
+}

--- a/tests/fixtures/ext-app/src/TestPageExt.PageExtension.al
+++ b/tests/fixtures/ext-app/src/TestPageExt.PageExtension.al
@@ -1,0 +1,21 @@
+pageextension 70000 "Test Item Card Ext" extends "Test Item Card"
+{
+    layout
+    {
+        addlast(General)
+        {
+            field("Custom Category"; Rec."Custom Category")
+            {
+                ApplicationArea = All;
+            }
+            field(Priority; Rec.Priority)
+            {
+                ApplicationArea = All;
+            }
+            field("Extended Status"; Rec."Extended Status")
+            {
+                ApplicationArea = All;
+            }
+        }
+    }
+}

--- a/tests/fixtures/ext-app/src/TestReportExt.ReportExtension.al
+++ b/tests/fixtures/ext-app/src/TestReportExt.ReportExtension.al
@@ -1,0 +1,15 @@
+reportextension 70000 "Test Item List Ext" extends "Test Item List"
+{
+    dataset
+    {
+        add(TestItem)
+        {
+            column(CustomCategory; "Custom Category")
+            {
+            }
+            column(Priority; Priority)
+            {
+            }
+        }
+    }
+}

--- a/tests/fixtures/ext-app/src/TestTableExt.TableExtension.al
+++ b/tests/fixtures/ext-app/src/TestTableExt.TableExtension.al
@@ -1,0 +1,21 @@
+tableextension 70000 "Test Item Ext" extends "Test Item"
+{
+    fields
+    {
+        field(70000; "Custom Category"; Text[50])
+        {
+            Caption = 'Custom Category';
+            DataClassification = CustomerContent;
+        }
+        field(70001; "Priority"; Integer)
+        {
+            Caption = 'Priority';
+            DataClassification = CustomerContent;
+        }
+        field(70002; "Extended Status"; Enum "Test Status")
+        {
+            Caption = 'Extended Status';
+            DataClassification = CustomerContent;
+        }
+    }
+}


### PR DESCRIPTION
…ension, EnumExtensionType, ReportExtension, PermissionSetExtension)

Addresses #17 - Extension objects in SymbolReference.json are now parsed, indexed, and searchable through all MCP tools. Key implementation details:

- Parser: handles actual compiler JSON keys (EnumExtensionTypes not EnumExtensions, ReportExtensions use Target not TargetObject), extracts base object names from TargetObject format (#appid#ObjectName), synthesizes Extends property for indexing
- Database: indexes extension fields, procedures, controls, tracks extension-to-base relationships via extensionsByBase index
- MCP tools: all tool enums and type filters updated to include extension types, field/control/data item queries work for extensions
- Tests: comprehensive 39-test suite with self-contained AL test fixtures (base app + extension app compiled to .app symbol packages)