### PR TITLE
fix: trim trailing signature bytes from signed .app packages #20 #21 #23

### DIFF
--- a/src/parser/zip-fallback.ts
+++ b/src/parser/zip-fallback.ts
@@ -25,17 +25,10 @@ export class ZipFallbackExtractor {
    * Extract SymbolReference.json from AL symbol package using yauzl
    */
   async extractSymbolReference(symbolPackagePath: string): Promise<Readable> {
-    // AL packages have a 40-byte NAVX header - skip it and read ZIP directly
+    // AL packages have a 40-byte NAVX header and signed packages have
+    // trailing signature bytes - extract just the ZIP portion
     const buffer = await fs.readFile(symbolPackagePath);
-    
-    // Find ZIP signature (PK header at byte 40)
-    const zipStart = this.findZipStart(buffer);
-    if (zipStart === -1) {
-      throw new Error('Not a valid AL package - ZIP signature not found');
-    }
-    
-    // Extract just the ZIP portion
-    const zipBuffer = buffer.slice(zipStart);
+    const zipBuffer = this.getZipBuffer(buffer);
     
     // Open ZIP from buffer using yauzl
     return new Promise((resolve, reject) => {
@@ -89,13 +82,7 @@ export class ZipFallbackExtractor {
    */
   async extractManifest(alPackagePath: string): Promise<ExtractedManifest> {
     const buffer = await fs.readFile(alPackagePath);
-    const zipStart = this.findZipStart(buffer);
-    
-    if (zipStart === -1) {
-      throw new Error('Not a valid AL package - ZIP signature not found');
-    }
-    
-    const zipBuffer = buffer.slice(zipStart);
+    const zipBuffer = this.getZipBuffer(buffer);
     
     return new Promise((resolve, reject) => {
       yauzl.fromBuffer(zipBuffer, { lazyEntries: true }, (err, zipfile) => {
@@ -194,6 +181,25 @@ export class ZipFallbackExtractor {
   }
 
   /**
+   * Extract the ZIP portion from an AL package buffer, stripping the NAVX
+   * header and any trailing signature bytes (signed packages).
+   * Returns just the ZIP data that yauzl can parse cleanly.
+   */
+  private getZipBuffer(buffer: Buffer): Buffer {
+    const zipStart = this.findZipStart(buffer);
+    if (zipStart === -1) {
+      throw new Error('Not a valid AL package - ZIP signature not found');
+    }
+
+    const zipEnd = this.findZipEnd(buffer, zipStart);
+    if (zipEnd !== -1) {
+      return buffer.slice(zipStart, zipEnd);
+    }
+    // Fallback: no EOCD found, return everything from zipStart (original behavior)
+    return buffer.slice(zipStart);
+  }
+
+  /**
    * Find ZIP signature in AL package buffer
    * AL packages have 40-byte NAVX header followed by ZIP data
    */
@@ -202,6 +208,41 @@ export class ZipFallbackExtractor {
     for (let i = 0; i < Math.min(buffer.length, 100); i++) {
       if (buffer[i] === 0x50 && buffer[i + 1] === 0x4B) {
         return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Find the end of ZIP data by locating the End of Central Directory (EOCD) record.
+   * Signed AL packages have trailing signature bytes (ending with NXSB magic)
+   * after the ZIP data. yauzl rejects these extra bytes, so we must trim them.
+   *
+   * EOCD record structure (22 bytes minimum):
+   *   Signature: 0x50 0x4B 0x05 0x06 (4 bytes)
+   *   ... fixed fields ...          (16 bytes)
+   *   Comment length:               (2 bytes at offset 20)
+   *   Comment:                      (variable)
+   *
+   * Returns the byte offset (relative to start of buffer) where ZIP data ends,
+   * or -1 if EOCD is not found.
+   */
+  private findZipEnd(buffer: Buffer, zipStart: number): number {
+    // EOCD signature: PK\x05\x06
+    // Scan backward from the end of the buffer to find it.
+    // The EOCD is at least 22 bytes, and the comment can be up to 65535 bytes,
+    // so we need to scan at most 22 + 65535 = 65557 bytes from the end.
+    const maxScan = Math.min(buffer.length - zipStart, 65557);
+    const scanStart = buffer.length - 4;
+    const scanEnd = buffer.length - maxScan;
+
+    for (let i = scanStart; i >= scanEnd && i >= zipStart; i--) {
+      if (buffer[i] === 0x50 && buffer[i + 1] === 0x4B &&
+          buffer[i + 2] === 0x05 && buffer[i + 3] === 0x06) {
+        // Found EOCD - read comment length (2 bytes, little-endian, at offset 20)
+        const commentLength = buffer.readUInt16LE(i + 20);
+        // ZIP data ends right after the EOCD record + comment
+        return i + 22 + commentLength;
       }
     }
     return -1;

--- a/tests/unit/zip-fallback.test.ts
+++ b/tests/unit/zip-fallback.test.ts
@@ -1,0 +1,238 @@
+import { ZipFallbackExtractor } from '../../src/parser/zip-fallback';
+import * as yauzl from 'yauzl';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+/**
+ * Build a minimal valid ZIP archive in-memory containing a single file.
+ * Returns a Buffer of pure ZIP data (no NAVX header, no trailing signature).
+ */
+function buildMinimalZip(fileName: string, content: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    // Use yauzl's counterpart (yazl) pattern: build ZIP by hand
+    // For simplicity, build the binary structure directly.
+    const fileNameBuf = Buffer.from(fileName, 'utf8');
+    const contentBuf = Buffer.from(content, 'utf8');
+
+    // Local file header (30 + fileName.length bytes)
+    const localHeader = Buffer.alloc(30 + fileNameBuf.length);
+    localHeader.writeUInt32LE(0x04034b50, 0);   // Local file header signature
+    localHeader.writeUInt16LE(20, 4);            // Version needed to extract (2.0)
+    localHeader.writeUInt16LE(0, 6);             // General purpose bit flag
+    localHeader.writeUInt16LE(0, 8);             // Compression method: stored
+    localHeader.writeUInt16LE(0, 10);            // Last mod file time
+    localHeader.writeUInt16LE(0, 12);            // Last mod file date
+    // CRC-32 - compute simple CRC
+    const crc = crc32(contentBuf);
+    localHeader.writeInt32LE(crc, 14);           // CRC-32
+    localHeader.writeUInt32LE(contentBuf.length, 18); // Compressed size
+    localHeader.writeUInt32LE(contentBuf.length, 22); // Uncompressed size
+    localHeader.writeUInt16LE(fileNameBuf.length, 26); // File name length
+    localHeader.writeUInt16LE(0, 28);            // Extra field length
+    fileNameBuf.copy(localHeader, 30);
+
+    // File data
+    const fileData = contentBuf;
+
+    // Central directory header (46 + fileName.length bytes)
+    const centralDirOffset = localHeader.length + fileData.length;
+    const centralHeader = Buffer.alloc(46 + fileNameBuf.length);
+    centralHeader.writeUInt32LE(0x02014b50, 0);  // Central directory header signature
+    centralHeader.writeUInt16LE(20, 4);           // Version made by
+    centralHeader.writeUInt16LE(20, 6);           // Version needed to extract
+    centralHeader.writeUInt16LE(0, 8);            // General purpose bit flag
+    centralHeader.writeUInt16LE(0, 10);           // Compression method: stored
+    centralHeader.writeUInt16LE(0, 12);           // Last mod file time
+    centralHeader.writeUInt16LE(0, 14);           // Last mod file date
+    centralHeader.writeInt32LE(crc, 16);          // CRC-32
+    centralHeader.writeUInt32LE(contentBuf.length, 20); // Compressed size
+    centralHeader.writeUInt32LE(contentBuf.length, 24); // Uncompressed size
+    centralHeader.writeUInt16LE(fileNameBuf.length, 28); // File name length
+    centralHeader.writeUInt16LE(0, 30);           // Extra field length
+    centralHeader.writeUInt16LE(0, 32);           // File comment length
+    centralHeader.writeUInt16LE(0, 34);           // Disk number start
+    centralHeader.writeUInt16LE(0, 36);           // Internal file attributes
+    centralHeader.writeUInt32LE(0, 38);           // External file attributes
+    centralHeader.writeUInt32LE(0, 42);           // Relative offset of local header
+    fileNameBuf.copy(centralHeader, 46);
+
+    // End of Central Directory record (22 bytes)
+    const eocd = Buffer.alloc(22);
+    eocd.writeUInt32LE(0x06054b50, 0);            // EOCD signature
+    eocd.writeUInt16LE(0, 4);                     // Disk number
+    eocd.writeUInt16LE(0, 6);                     // Disk with central directory
+    eocd.writeUInt16LE(1, 8);                     // Number of entries on this disk
+    eocd.writeUInt16LE(1, 10);                    // Total number of entries
+    eocd.writeUInt32LE(centralHeader.length, 12); // Size of central directory
+    eocd.writeUInt32LE(centralDirOffset, 16);     // Offset of start of central directory
+    eocd.writeUInt16LE(0, 20);                    // Comment length
+
+    resolve(Buffer.concat([localHeader, fileData, centralHeader, eocd]));
+  });
+}
+
+/**
+ * Simple CRC-32 implementation for test fixtures.
+ */
+function crc32(buf: Buffer): number {
+  let crc = 0xFFFFFFFF;
+  for (let i = 0; i < buf.length; i++) {
+    crc ^= buf[i];
+    for (let j = 0; j < 8; j++) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xEDB88320 : 0);
+    }
+  }
+  return (crc ^ 0xFFFFFFFF) | 0; // return as signed 32-bit
+}
+
+/**
+ * Build a 40-byte NAVX header (the standard prefix for .app files).
+ */
+function buildNavxHeader(): Buffer {
+  const header = Buffer.alloc(40);
+  // NAVX magic bytes at the start (4E 41 56 58 = "NAVX")
+  header.write('NAVX', 0, 'ascii');
+  // Rest is metadata — fill with zeros for testing
+  return header;
+}
+
+/**
+ * Build a fake trailing signature block similar to signed BC packages.
+ * Ends with NXSB magic bytes as described in issue #20.
+ */
+function buildTrailingSignature(size: number = 10240): Buffer {
+  const sig = Buffer.alloc(size);
+  // Fill with random-ish data to simulate a digital signature
+  for (let i = 0; i < size; i++) {
+    sig[i] = (i * 7 + 13) & 0xFF;
+  }
+  // NXSB magic at the end (4 bytes)
+  sig.write('NXSB', size - 4, 'ascii');
+  return sig;
+}
+
+describe('ZipFallbackExtractor - signed package handling (issue #20)', () => {
+  let extractor: ZipFallbackExtractor;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = path.join(__dirname, '..', 'fixtures', 'tmp-zip-test');
+    await fs.mkdir(tmpDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    extractor = new ZipFallbackExtractor();
+  });
+
+  describe('unsigned packages (no trailing signature)', () => {
+    it('should extract NavxManifest.xml from unsigned package', async () => {
+      const manifestXml = `<?xml version="1.0" encoding="utf-8"?>
+<Package><App Id="test-id-123" Name="Test App" Publisher="TestPub" Version="1.0.0.0" /></Package>`;
+
+      const zipData = await buildMinimalZip('NavxManifest.xml', manifestXml);
+      const navxHeader = buildNavxHeader();
+      const packageBuffer = Buffer.concat([navxHeader, zipData]);
+
+      const appPath = path.join(tmpDir, 'unsigned.app');
+      await fs.writeFile(appPath, packageBuffer);
+
+      const manifest = await extractor.extractManifest(appPath);
+      expect(manifest.id).toBe('test-id-123');
+      expect(manifest.name).toBe('Test App');
+      expect(manifest.publisher).toBe('TestPub');
+      expect(manifest.version).toBe('1.0.0.0');
+    });
+  });
+
+  describe('signed packages (with trailing signature bytes)', () => {
+    it('should extract NavxManifest.xml from signed package', async () => {
+      const manifestXml = `<?xml version="1.0" encoding="utf-8"?>
+<Package><App Id="signed-id-456" Name="Signed App" Publisher="Microsoft" Version="27.0.0.0" /></Package>`;
+
+      const zipData = await buildMinimalZip('NavxManifest.xml', manifestXml);
+      const navxHeader = buildNavxHeader();
+      const trailingSig = buildTrailingSignature(10240); // ~10KB trailing signature
+      const packageBuffer = Buffer.concat([navxHeader, zipData, trailingSig]);
+
+      const appPath = path.join(tmpDir, 'signed.app');
+      await fs.writeFile(appPath, packageBuffer);
+
+      // This would fail before the fix with:
+      // "Invalid comment length. Expected: XXXXX. Found: 0."
+      const manifest = await extractor.extractManifest(appPath);
+      expect(manifest.id).toBe('signed-id-456');
+      expect(manifest.name).toBe('Signed App');
+      expect(manifest.publisher).toBe('Microsoft');
+      expect(manifest.version).toBe('27.0.0.0');
+    });
+
+    it('should extract SymbolReference.json from signed package', async () => {
+      const symbolJson = JSON.stringify({
+        Namespaces: [],
+        Tables: [{ Id: 18, Name: 'Customer' }]
+      });
+
+      const zipData = await buildMinimalZip('SymbolReference.json', symbolJson);
+      const navxHeader = buildNavxHeader();
+      const trailingSig = buildTrailingSignature(8192);
+      const packageBuffer = Buffer.concat([navxHeader, zipData, trailingSig]);
+
+      const appPath = path.join(tmpDir, 'signed-symbols.app');
+      await fs.writeFile(appPath, packageBuffer);
+
+      const stream = await extractor.extractSymbolReference(appPath);
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      const content = Buffer.concat(chunks).toString('utf8');
+      const parsed = JSON.parse(content);
+      expect(parsed.Tables).toBeDefined();
+      expect(parsed.Tables[0].Name).toBe('Customer');
+    });
+
+    it('should handle large trailing signatures (50KB+)', async () => {
+      const manifestXml = `<?xml version="1.0" encoding="utf-8"?>
+<Package><App Id="big-sig" Name="Big Sig App" Publisher="Microsoft" Version="1.0.0.0" /></Package>`;
+
+      const zipData = await buildMinimalZip('NavxManifest.xml', manifestXml);
+      const navxHeader = buildNavxHeader();
+      const trailingSig = buildTrailingSignature(51200); // 50KB
+      const packageBuffer = Buffer.concat([navxHeader, zipData, trailingSig]);
+
+      const appPath = path.join(tmpDir, 'big-signed.app');
+      await fs.writeFile(appPath, packageBuffer);
+
+      const manifest = await extractor.extractManifest(appPath);
+      expect(manifest.id).toBe('big-sig');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should reject buffer without ZIP signature', async () => {
+      const garbage = Buffer.alloc(100, 0x42);
+      const appPath = path.join(tmpDir, 'garbage.app');
+      await fs.writeFile(appPath, garbage);
+
+      await expect(extractor.extractManifest(appPath))
+        .rejects.toThrow('ZIP signature not found');
+    });
+
+    it('should handle package with no NAVX header (ZIP starts at offset 0)', async () => {
+      const manifestXml = `<?xml version="1.0" encoding="utf-8"?>
+<Package><App Id="no-header" Name="No Header" Publisher="Test" Version="1.0.0.0" /></Package>`;
+
+      const zipData = await buildMinimalZip('NavxManifest.xml', manifestXml);
+      // No NAVX header — ZIP starts immediately (PK signature at byte 0)
+      const appPath = path.join(tmpDir, 'no-header.app');
+      await fs.writeFile(appPath, zipData);
+
+      const manifest = await extractor.extractManifest(appPath);
+      expect(manifest.id).toBe('no-header');
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Only unsigned packages (e.g. `Microsoft_System`) seemed to load successfully. All signed Microsoft packages — `Base Application`, `System Application`, `Business Foundation` — failed with:

```
  Error: Invalid comment length. Expected: 10240. Found: 0.
  Are there extra bytes at the end of the file?
```

This affected all platforms (macOS, Windows, Linux) when the ZipFallbackExtractor code path is used. Initially reported as macOS-only (#20), but confirmed to also impact Windows users (#21, #23). 

  ## Root Cause

  Signed BC `.app` files have this binary layout:

  [40-byte NAVX header] [ZIP data] [trailing digital signature ~10KB]

  The existing code correctly skipped the NAVX header, but passed `ZIP data + trailing signature` to yauzl. yauzl strictly validates that no bytes exist after the ZIP's End of Central Directory (EOCD) record and has no option to tolerate
  trailing data.

  ## Fix

  Added `findZipEnd()` which scans backward through the buffer to locate the EOCD record (`PK\x05\x06`) and calculates the exact byte offset where the ZIP data ends. Added `getZipBuffer()` as a shared helper used by both
  `extractSymbolReference()` and `extractManifest()` that trims the buffer to just the clean ZIP portion before passing it to yauzl. Falls back gracefully to the original behavior if no EOCD is found.

  ## Testing

  - Unit tests added in `tests/unit/zip-fallback.test.ts` with synthetic fixtures simulating signed packages (NAVX header + ZIP + trailing signature bytes)
  - Manually verified on macOS with a real signed `Microsoft_Base Application 26.3.36158.36321.app` (41 MB → 55.9 MB `SymbolReference.json` extracted successfully)

  ## Before / After

  | Package | Before | After |
  |---|---|---|
  | `Microsoft_System` (unsigned) | ✅ | ✅ |
  | `Microsoft_Base Application` (signed) | ❌ | ✅ |
  | `Microsoft_System Application` (signed) | ❌ | ✅ |
  | `Microsoft_Business Foundation` (signed) | ❌ | ✅ |