### PR TITLE
fix: handle signed .app packages with NXSB trailing signature data

### DIFF
--- a/src/parser/zip-fallback.ts
+++ b/src/parser/zip-fallback.ts
@@ -219,9 +219,9 @@ export class ZipFallbackExtractor {
    */
   private findZipEnd(buffer: Buffer): number {
     // EOCD signature: PK\x05\x06 (0x50 0x4B 0x05 0x06)
-    // EOCD can be at most 22 bytes (fixed) + 65535 bytes (max comment) from end
-    const maxSearch = Math.min(buffer.length, 22 + 65535);
-    const searchStart = buffer.length - maxSearch;
+    // Scan backwards from end to zipStart to handle any amount of trailing data
+    const zipStart = this.findZipStart(buffer);
+    const searchStart = zipStart >= 0 ? zipStart : 0;
 
     for (let i = buffer.length - 22; i >= searchStart; i--) {
       if (buffer[i] === 0x50 && buffer[i + 1] === 0x4B &&

--- a/src/parser/zip-fallback.ts
+++ b/src/parser/zip-fallback.ts
@@ -33,9 +33,10 @@ export class ZipFallbackExtractor {
     if (zipStart === -1) {
       throw new Error('Not a valid AL package - ZIP signature not found');
     }
-    
-    // Extract just the ZIP portion
-    const zipBuffer = buffer.slice(zipStart);
+
+    // Extract just the ZIP portion, excluding any trailing NXSB signature data
+    const zipEnd = this.findZipEnd(buffer);
+    const zipBuffer = buffer.slice(zipStart, zipEnd);
     
     // Open ZIP from buffer using yauzl
     return new Promise((resolve, reject) => {
@@ -90,12 +91,14 @@ export class ZipFallbackExtractor {
   async extractManifest(alPackagePath: string): Promise<ExtractedManifest> {
     const buffer = await fs.readFile(alPackagePath);
     const zipStart = this.findZipStart(buffer);
-    
+
     if (zipStart === -1) {
       throw new Error('Not a valid AL package - ZIP signature not found');
     }
-    
-    const zipBuffer = buffer.slice(zipStart);
+
+    // Exclude any trailing NXSB signature data from signed packages
+    const zipEnd = this.findZipEnd(buffer);
+    const zipBuffer = buffer.slice(zipStart, zipEnd);
     
     return new Promise((resolve, reject) => {
       yauzl.fromBuffer(zipBuffer, { lazyEntries: true }, (err, zipfile) => {
@@ -205,6 +208,32 @@ export class ZipFallbackExtractor {
       }
     }
     return -1;
+  }
+
+  /**
+   * Find the true end of the ZIP data in the buffer.
+   * Signed AL packages have an NXSB trailer (~10KB) after the ZIP data
+   * that causes yauzl to reject the buffer with "Invalid comment length".
+   * This method scans backwards for the EOCD record and calculates the
+   * actual ZIP end position, excluding any trailing signature data.
+   */
+  private findZipEnd(buffer: Buffer): number {
+    // EOCD signature: PK\x05\x06 (0x50 0x4B 0x05 0x06)
+    // EOCD can be at most 22 bytes (fixed) + 65535 bytes (max comment) from end
+    const maxSearch = Math.min(buffer.length, 22 + 65535);
+    const searchStart = buffer.length - maxSearch;
+
+    for (let i = buffer.length - 22; i >= searchStart; i--) {
+      if (buffer[i] === 0x50 && buffer[i + 1] === 0x4B &&
+          buffer[i + 2] === 0x05 && buffer[i + 3] === 0x06) {
+        // Found EOCD - read comment length at offset 20 (2 bytes, little-endian)
+        const commentLength = buffer.readUInt16LE(i + 20);
+        return i + 22 + commentLength;
+      }
+    }
+
+    // No EOCD found - return full buffer length as fallback
+    return buffer.length;
   }
 
   /**

--- a/tests/signed-app.test.ts
+++ b/tests/signed-app.test.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as os from 'os';
 import * as fs from 'fs';
 import { ZipFallbackExtractor } from '../src/parser/zip-fallback';
 
@@ -15,10 +16,12 @@ const describeOrSkip = fixtureExists ? describe : describe.skip;
  */
 describeOrSkip('Signed .app integration tests (compiled fixtures)', () => {
   let extractor: ZipFallbackExtractor;
+  let tmpDir: string;
   let signedAppPath: string;
 
   beforeAll(() => {
     extractor = new ZipFallbackExtractor();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'signed-app-test-'));
 
     // Create a signed version by appending an NXSB trailer
     const originalBuffer = fs.readFileSync(FIXTURE_APP);
@@ -29,14 +32,12 @@ describeOrSkip('Signed .app integration tests (compiled fixtures)', () => {
     trailer.write('NXSB', trailer.length - 4, 'ascii');
 
     const signedBuffer = Buffer.concat([originalBuffer, trailer]);
-    signedAppPath = path.join(FIXTURE_DIR, 'TestPublisher_Base Test App_1.0.0.0_signed.app');
+    signedAppPath = path.join(tmpDir, 'signed.app');
     fs.writeFileSync(signedAppPath, signedBuffer);
   });
 
   afterAll(() => {
-    if (fs.existsSync(signedAppPath)) {
-      fs.unlinkSync(signedAppPath);
-    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it('should extract identical manifest from unsigned and signed fixture', async () => {

--- a/tests/signed-app.test.ts
+++ b/tests/signed-app.test.ts
@@ -1,0 +1,64 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import { ZipFallbackExtractor } from '../src/parser/zip-fallback';
+
+const FIXTURE_DIR = path.join(__dirname, 'fixtures', 'compiled');
+const FIXTURE_APP = path.join(FIXTURE_DIR, 'TestPublisher_Base Test App_1.0.0.0.app');
+
+const fixtureExists = fs.existsSync(FIXTURE_APP);
+const describeOrSkip = fixtureExists ? describe : describe.skip;
+
+/**
+ * Integration tests using compiled test fixture .app files.
+ * Appends a synthetic NXSB trailer to the fixture to simulate a signed package,
+ * then verifies both extraction methods produce identical results.
+ */
+describeOrSkip('Signed .app integration tests (compiled fixtures)', () => {
+  let extractor: ZipFallbackExtractor;
+  let signedAppPath: string;
+
+  beforeAll(() => {
+    extractor = new ZipFallbackExtractor();
+
+    // Create a signed version by appending an NXSB trailer
+    const originalBuffer = fs.readFileSync(FIXTURE_APP);
+    const trailer = Buffer.alloc(10241);
+    for (let i = 0; i < trailer.length - 4; i++) {
+      trailer[i] = (i * 7 + 13) & 0xFF;
+    }
+    trailer.write('NXSB', trailer.length - 4, 'ascii');
+
+    const signedBuffer = Buffer.concat([originalBuffer, trailer]);
+    signedAppPath = path.join(FIXTURE_DIR, 'TestPublisher_Base Test App_1.0.0.0_signed.app');
+    fs.writeFileSync(signedAppPath, signedBuffer);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(signedAppPath)) {
+      fs.unlinkSync(signedAppPath);
+    }
+  });
+
+  it('should extract identical manifest from unsigned and signed fixture', async () => {
+    const unsignedManifest = await extractor.extractManifest(FIXTURE_APP);
+    const signedManifest = await extractor.extractManifest(signedAppPath);
+
+    expect(signedManifest).toEqual(unsignedManifest);
+  });
+
+  it('should extract identical SymbolReference.json from unsigned and signed fixture', async () => {
+    const readStream = async (appPath: string): Promise<string> => {
+      const stream = await extractor.extractSymbolReference(appPath);
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+      return Buffer.concat(chunks).toString('utf8');
+    };
+
+    const unsignedJson = await readStream(FIXTURE_APP);
+    const signedJson = await readStream(signedAppPath);
+
+    expect(JSON.parse(signedJson)).toEqual(JSON.parse(unsignedJson));
+  });
+});

--- a/tests/unit/zip-fallback.test.ts
+++ b/tests/unit/zip-fallback.test.ts
@@ -3,6 +3,24 @@ import * as os from 'os';
 import * as fs from 'fs';
 import { ZipFallbackExtractor } from '../../src/parser/zip-fallback';
 
+/** CRC-32 lookup table (compatible with Node 18 which lacks zlib.crc32) */
+const CRC32_TABLE = new Uint32Array(256);
+for (let i = 0; i < 256; i++) {
+  let c = i;
+  for (let j = 0; j < 8; j++) {
+    c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+  }
+  CRC32_TABLE[i] = c;
+}
+
+function crc32(buf: Buffer): number {
+  let crc = 0xFFFFFFFF;
+  for (let i = 0; i < buf.length; i++) {
+    crc = CRC32_TABLE[(crc ^ buf[i]) & 0xFF] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
 /**
  * Build a minimal valid ZIP buffer containing a single uncompressed file.
  * Constructs the ZIP manually: local file header + data + central directory + EOCD.
@@ -11,9 +29,7 @@ function buildZipBuffer(fileName: string, content: string): Buffer {
   const fileNameBuf = Buffer.from(fileName, 'utf8');
   const fileData = Buffer.from(content, 'utf8');
 
-  // CRC-32 using Node.js zlib
-  const zlib = require('zlib');
-  const crc = zlib.crc32(fileData);
+  const crc = crc32(fileData);
 
   // Local file header (30 bytes + filename)
   const lfh = Buffer.alloc(30 + fileNameBuf.length);

--- a/tests/unit/zip-fallback.test.ts
+++ b/tests/unit/zip-fallback.test.ts
@@ -1,0 +1,220 @@
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import { ZipFallbackExtractor } from '../../src/parser/zip-fallback';
+
+/**
+ * Build a minimal valid ZIP buffer containing a single uncompressed file.
+ * Constructs the ZIP manually: local file header + data + central directory + EOCD.
+ */
+function buildZipBuffer(fileName: string, content: string): Buffer {
+  const fileNameBuf = Buffer.from(fileName, 'utf8');
+  const fileData = Buffer.from(content, 'utf8');
+
+  // CRC-32 using Node.js zlib
+  const zlib = require('zlib');
+  const crc = zlib.crc32(fileData);
+
+  // Local file header (30 bytes + filename)
+  const lfh = Buffer.alloc(30 + fileNameBuf.length);
+  lfh.writeUInt32LE(0x04034b50, 0);        // Local file header signature
+  lfh.writeUInt16LE(20, 4);                 // Version needed (2.0)
+  lfh.writeUInt16LE(0, 6);                  // General purpose flags
+  lfh.writeUInt16LE(0, 8);                  // Compression: stored (no compression)
+  lfh.writeUInt16LE(0, 10);                 // Last mod time
+  lfh.writeUInt16LE(0, 12);                 // Last mod date
+  lfh.writeUInt32LE(crc, 14);              // CRC-32
+  lfh.writeUInt32LE(fileData.length, 18);  // Compressed size
+  lfh.writeUInt32LE(fileData.length, 22);  // Uncompressed size
+  lfh.writeUInt16LE(fileNameBuf.length, 26); // Filename length
+  lfh.writeUInt16LE(0, 28);                 // Extra field length
+  fileNameBuf.copy(lfh, 30);
+
+  // Central directory file header (46 bytes + filename)
+  const cdOffset = lfh.length + fileData.length;
+  const cd = Buffer.alloc(46 + fileNameBuf.length);
+  cd.writeUInt32LE(0x02014b50, 0);          // Central directory signature
+  cd.writeUInt16LE(20, 4);                   // Version made by
+  cd.writeUInt16LE(20, 6);                   // Version needed
+  cd.writeUInt16LE(0, 8);                    // General purpose flags
+  cd.writeUInt16LE(0, 10);                   // Compression: stored
+  cd.writeUInt16LE(0, 12);                   // Last mod time
+  cd.writeUInt16LE(0, 14);                   // Last mod date
+  cd.writeUInt32LE(crc, 16);                // CRC-32
+  cd.writeUInt32LE(fileData.length, 20);    // Compressed size
+  cd.writeUInt32LE(fileData.length, 24);    // Uncompressed size
+  cd.writeUInt16LE(fileNameBuf.length, 28); // Filename length
+  cd.writeUInt16LE(0, 30);                   // Extra field length
+  cd.writeUInt16LE(0, 32);                   // File comment length
+  cd.writeUInt16LE(0, 34);                   // Disk number start
+  cd.writeUInt16LE(0, 36);                   // Internal file attributes
+  cd.writeUInt32LE(0, 38);                   // External file attributes
+  cd.writeUInt32LE(0, 42);                   // Relative offset of local header
+  fileNameBuf.copy(cd, 46);
+
+  // EOCD (22 bytes)
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);        // EOCD signature
+  eocd.writeUInt16LE(0, 4);                  // Disk number
+  eocd.writeUInt16LE(0, 6);                  // Disk with central directory
+  eocd.writeUInt16LE(1, 8);                  // Entries on this disk
+  eocd.writeUInt16LE(1, 10);                 // Total entries
+  eocd.writeUInt32LE(cd.length, 12);         // Central directory size
+  eocd.writeUInt32LE(lfh.length + fileData.length, 16); // CD offset
+  eocd.writeUInt16LE(0, 20);                 // Comment length
+
+  return Buffer.concat([lfh, fileData, cd, eocd]);
+}
+
+/**
+ * Build a 40-byte NAVX header matching real AL packages.
+ */
+function buildNavxHeader(): Buffer {
+  const header = Buffer.alloc(40);
+  header.write('NAVX', 0, 'ascii');
+  header.writeUInt32LE(40, 4);
+  header.writeUInt32LE(2, 8);
+  header.write('NAVX', 36, 'ascii');
+  return header;
+}
+
+/**
+ * Build an NXSB trailer of the specified size.
+ * Real signed packages have ~10KB trailers ending with 'NXSB' magic.
+ */
+function buildNxsbTrailer(size: number): Buffer {
+  const trailer = Buffer.alloc(size);
+  for (let i = 0; i < size - 4; i++) {
+    trailer[i] = (i * 7 + 13) & 0xFF;
+  }
+  trailer.write('NXSB', size - 4, 'ascii');
+  return trailer;
+}
+
+const MANIFEST_XML = `<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+  <App Id="test-id-1234" Name="Test App" Publisher="TestPublisher" Version="1.0.0.0" />
+</Package>`;
+
+const SYMBOL_JSON = `{"AppId":"test-id-1234","Name":"Test App","Publisher":"TestPublisher","Version":"1.0.0.0","Tables":[]}`;
+
+describe('ZipFallbackExtractor - signed package handling', () => {
+  let extractor: ZipFallbackExtractor;
+  let tmpDir: string;
+
+  beforeAll(() => {
+    extractor = new ZipFallbackExtractor();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zip-fallback-test-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeTempApp(name: string, buffer: Buffer): string {
+    const filePath = path.join(tmpDir, name);
+    fs.writeFileSync(filePath, buffer);
+    return filePath;
+  }
+
+  function buildUnsignedApp(zipContent: { name: string; content: string }): Buffer {
+    const navx = buildNavxHeader();
+    const zip = buildZipBuffer(zipContent.name, zipContent.content);
+    return Buffer.concat([navx, zip]);
+  }
+
+  function buildSignedApp(zipContent: { name: string; content: string }, trailerSize: number): Buffer {
+    const navx = buildNavxHeader();
+    const zip = buildZipBuffer(zipContent.name, zipContent.content);
+    const trailer = buildNxsbTrailer(trailerSize);
+    return Buffer.concat([navx, zip, trailer]);
+  }
+
+  describe('extractManifest', () => {
+    it('should extract manifest from unsigned .app', async () => {
+      const appBuffer = buildUnsignedApp({ name: 'NavxManifest.xml', content: MANIFEST_XML });
+      const appPath = writeTempApp('unsigned.app', appBuffer);
+
+      const manifest = await extractor.extractManifest(appPath);
+      expect(manifest.id).toBe('test-id-1234');
+      expect(manifest.name).toBe('Test App');
+      expect(manifest.publisher).toBe('TestPublisher');
+      expect(manifest.version).toBe('1.0.0.0');
+    });
+
+    it('should extract manifest from signed .app with NXSB trailer', async () => {
+      const appBuffer = buildSignedApp({ name: 'NavxManifest.xml', content: MANIFEST_XML }, 104);
+      const appPath = writeTempApp('signed-small.app', appBuffer);
+
+      const manifest = await extractor.extractManifest(appPath);
+      expect(manifest.id).toBe('test-id-1234');
+      expect(manifest.name).toBe('Test App');
+      expect(manifest.publisher).toBe('TestPublisher');
+    });
+
+    it('should extract manifest from signed .app with large trailer (10KB+)', async () => {
+      const appBuffer = buildSignedApp({ name: 'NavxManifest.xml', content: MANIFEST_XML }, 10241);
+      const appPath = writeTempApp('signed-large.app', appBuffer);
+
+      const manifest = await extractor.extractManifest(appPath);
+      expect(manifest.id).toBe('test-id-1234');
+      expect(manifest.name).toBe('Test App');
+    });
+
+    it('should reject file with no ZIP signature', async () => {
+      const garbage = Buffer.alloc(200, 0x42);
+      const appPath = writeTempApp('garbage.app', garbage);
+
+      await expect(extractor.extractManifest(appPath)).rejects.toThrow('ZIP signature not found');
+    });
+  });
+
+  describe('extractSymbolReference', () => {
+    it('should extract SymbolReference.json from unsigned .app', async () => {
+      const appBuffer = buildUnsignedApp({ name: 'SymbolReference.json', content: SYMBOL_JSON });
+      const appPath = writeTempApp('unsigned-sym.app', appBuffer);
+
+      const stream = await extractor.extractSymbolReference(appPath);
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+      const json = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      expect(json.AppId).toBe('test-id-1234');
+      expect(json.Name).toBe('Test App');
+    });
+
+    it('should extract SymbolReference.json from signed .app with NXSB trailer', async () => {
+      const appBuffer = buildSignedApp({ name: 'SymbolReference.json', content: SYMBOL_JSON }, 104);
+      const appPath = writeTempApp('signed-sym.app', appBuffer);
+
+      const stream = await extractor.extractSymbolReference(appPath);
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+      const json = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      expect(json.AppId).toBe('test-id-1234');
+    });
+
+    it('should extract SymbolReference.json from signed .app with large trailer (10KB+)', async () => {
+      const appBuffer = buildSignedApp({ name: 'SymbolReference.json', content: SYMBOL_JSON }, 10241);
+      const appPath = writeTempApp('signed-sym-large.app', appBuffer);
+
+      const stream = await extractor.extractSymbolReference(appPath);
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+      const json = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      expect(json.AppId).toBe('test-id-1234');
+    });
+
+    it('should reject file with no ZIP signature', async () => {
+      const garbage = Buffer.alloc(200, 0x42);
+      const appPath = writeTempApp('garbage-sym.app', garbage);
+
+      await expect(extractor.extractSymbolReference(appPath)).rejects.toThrow('ZIP signature not found');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Signed BC `.app` packages include a ~10KB NXSB trailer after the ZIP data that `yauzl` rejects with `"Invalid comment length"`
- Added `findZipEnd()` method that scans backwards for the ZIP EOCD record to determine the true ZIP boundary, excluding trailing signature bytes
- Updated both `extractSymbolReference()` and `extractManifest()` to use `buffer.slice(zipStart, zipEnd)` instead of `buffer.slice(zipStart)`
- Verified against real 43MB signed Microsoft Base Application package (68MB SymbolReference.json extracted successfully)

Fixes #20, fixes #21, fixes #23

## Test plan

- [x] 8 new unit tests with synthetic signed/unsigned `.app` buffers (no fixture dependencies)
- [x] 2 integration tests using compiled fixture with appended NXSB trailer
- [x] Manual verification against real signed `Microsoft_Base Application_22.2.56969.58291.app`
- [x] Full test suite passes (144 tests, 0 failures)