### PR TITLE
feat: add repository URL and commit fields to package and manifest in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Extract repository URL and commit hash from AL package manifests (NavxManifest.xml and AL CLI) and expose via `al_packages` list
+
 ### Fixed
 - Parse and index procedures for Table objects (#11)
 - Strip trailing null characters from JSON to fix AppSource package parsing (#12)

--- a/src/cli/al-cli.ts
+++ b/src/cli/al-cli.ts
@@ -14,6 +14,10 @@ export interface ALAppManifest {
     publisher: string;
     version: string;
   }[];
+  source?: {
+    repositoryUrl?: string;
+    commit?: string;
+  };
 }
 
 export class ALCliWrapper {

--- a/src/core/package-manager.ts
+++ b/src/core/package-manager.ts
@@ -176,7 +176,9 @@ export class ALPackageManager {
         id: dep.id,
         version: dep.version
       })),
-      filePath: packagePath
+      filePath: packagePath,
+      repositoryUrl: manifest.repositoryUrl,
+      commit: manifest.commit
     };
 
     return {
@@ -218,7 +220,9 @@ export class ALPackageManager {
           id: dep.id,
           version: dep.version
         })),
-        filePath: packagePath
+        filePath: packagePath,
+        repositoryUrl: manifest.source?.repositoryUrl,
+        commit: manifest.source?.commit
       };
 
       return {

--- a/src/parser/zip-fallback.ts
+++ b/src/parser/zip-fallback.ts
@@ -14,6 +14,8 @@ export interface ExtractedManifest {
     publisher: string;
     version: string;
   }[];
+  repositoryUrl?: string;
+  commit?: string;
 }
 
 /**
@@ -160,6 +162,10 @@ export class ZipFallbackExtractor {
     const publisher = getAttrValue('App', 'Publisher') || getTagValue('Publisher');
     const version = getAttrValue('App', 'Version') || getTagValue('Version');
 
+    // Extract repository URL and commit hash from <Source RepositoryUrl="..." Commit="..." /> element
+    const repositoryUrl = getAttrValue('Source', 'RepositoryUrl') || undefined;
+    const commit = getAttrValue('Source', 'Commit') || undefined;
+
     // Extract dependencies
     const dependencies: ExtractedManifest['dependencies'] = [];
     const depRegex = /<Dependency[^>]*Id="([^"]*)"[^>]*Name="([^"]*)"[^>]*Publisher="([^"]*)"[^>]*(?:MinVersion|Version)="([^"]*)"/gi;
@@ -192,7 +198,9 @@ export class ZipFallbackExtractor {
       name,
       publisher,
       version,
-      dependencies: dependencies.length > 0 ? dependencies : undefined
+      dependencies: dependencies.length > 0 ? dependencies : undefined,
+      repositoryUrl: repositoryUrl || undefined,
+      commit: commit || undefined
     };
   }
 

--- a/src/types/al-types.ts
+++ b/src/types/al-types.ts
@@ -154,6 +154,8 @@ export interface ALPackageInfo {
   publisher: string;
   dependencies: ALPackageDependency[];
   filePath: string;
+  repositoryUrl?: string;
+  commit?: string;
 }
 
 export interface ALPackageDependency {


### PR DESCRIPTION
Extracts source repository URL and commit hash from AL package manifests and exposes them via al_packages list. This enables AI assistants to link packages back to their source repositories.

User Story
An AI agent working on an AL project needs to understand how a dependency works internally. Using al_packages list, the agent retrieves the repositoryUrl and commit of the dependency. It then clones the source repository at the exact commit the package was built from, giving it full access to the original AL source code for deeper analysis, debugging, or refactoring guidance - without the developer having to manually locate or provide the dependency's source.